### PR TITLE
Refine introduction in article on typing object parameters in TypeScript

### DIFF
--- a/content/approaches-for-typing-object-parameters-in-typescript/index.mdx
+++ b/content/approaches-for-typing-object-parameters-in-typescript/index.mdx
@@ -12,7 +12,7 @@ tags:
   - web development
 ---
 
-When working with TypeScript generics, one common challenge is ensuring type safety while maintaining flexibility in function parameters. This article explores various approaches for typing object parameters using generics, inspired by scenarios from the TypeScript Generics Workshop.
+When working with TypeScript generics, one common challenge is ensuring type safety while maintaining flexibility in function parameters. This article explores various approaches for typing object parameters using generics.
 
 > **Problem Overview**  
 > We aim to create a function that takes an object with two properties (`x` and `y`) of generic types and returns an object mapping these properties to `primary` and `secondary`. Here's a basic implementation:


### PR DESCRIPTION
This pull request includes a minor change to the content of an article on typing object parameters in TypeScript. The change removes a reference to the TypeScript Generics Workshop to streamline the article's introduction.

Content update:

* [`content/approaches-for-typing-object-parameters-in-typescript/index.mdx`](diffhunk://#diff-74ca983d08bf73e37a780070f2c61c5a4857ca1a7e524699a35c9ee745b156a1L15-R15): Removed the mention of the TypeScript Generics Workshop from the introductory paragraph.