### PR TITLE
Update publication dates for "Stop Avoiding Classes in TypeScript"

### DIFF
--- a/content/stop-avoiding-classes-in-typescript/index.mdx
+++ b/content/stop-avoiding-classes-in-typescript/index.mdx
@@ -2,8 +2,8 @@
 title: "Stop Avoiding Classes in TypeScript: Why They’re More Than Just Syntax"
 description: "Learn why classes in TypeScript should not be avoided, how they enhance object creation and type safety, and when they become essential in your codebase."
 image: "../../public/posts/stop-avoiding-classes-in-typescript.jpg"
-publishedAt: "2025/01/11"
-updatedAt: "2025/01/11"
+publishedAt: "2025/01/14"
+updatedAt: "2025/01/14"
 author: "Roy Lopez"
 isPublished: true
 tags:


### PR DESCRIPTION
This pull request includes a small change to the `content/stop-avoiding-classes-in-typescript/index.mdx` file. The change updates the `publishedAt` and `updatedAt` dates to reflect the correct publication date.

* [`content/stop-avoiding-classes-in-typescript/index.mdx`](diffhunk://#diff-3a340bd645e615509068b057e1344f3da8865f781721df3666ae37ca267c021bL5-R6): Updated `publishedAt` and `updatedAt` dates from "2025/01/11" to "2025/01/14".